### PR TITLE
Feature/ Adding location us-central1 in profiles

### DIFF
--- a/profiles.yml
+++ b/profiles.yml
@@ -9,6 +9,7 @@ clara_case:
         dataset: "{{ env_var('DEV_DATASET') }}"
         threads: 4 # Must be a value of 1 or greater
         keyfile: "{{ env_var('DEV_KEYFILE') }}"
+        location: us-central1
 
     prod:
         type: bigquery
@@ -17,3 +18,4 @@ clara_case:
         dataset: "{{ env_var('PROD_DATASET') }}"
         threads: 4 # Must be a value of 1 or greater
         keyfile: "{{ env_var('PROD_KEYFILE') }}"
+        location: us-central1


### PR DESCRIPTION
## Changes Description
I added a location in profiles.yml.

## Related Issues
None.

## Why is this change required?
If we leave without the location, than bigquery decides which location the schema will be created and will result in error.

## DBT-Specific Changes
- Models affected: none.
- Tests performed: none.

## Impact Assessment
None.

## Checklist
- [X] `dbt run` and `dbt test` were successful
- [X] Documentation updated
- [X] Code follows project guidelines
- [X] Self-review completed
